### PR TITLE
Add round-robin support for multiple GitHub tokens

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,29 +5,24 @@ on: [push, pull_request]
 jobs:
   tests:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php: ['8.0', '8.1']
-
-      fail-fast: false
 
     services:
       mysql:
-        image: mariadb:latest
+        image: mariadb:10.11
         env:
           MYSQL_DATABASE: test
           MYSQL_ROOT_PASSWORD: password
-        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+        options: --health-cmd="mysqladmin ping -h 127.0.0.1 -ppassword --silent" --health-interval=5s --health-timeout=5s --health-retries=10
         ports:
           - 3306:3306
 
-    name: PHP ${{ matrix.php }} Tests
+    name: PHP 8.4 Tests
     steps:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
-          extensions: json, mbstring, xml, tokenizer
+          php-version: '8.4'
+          extensions: json, mbstring, xml, tokenizer, pdo_mysql
           coverage: none
 
       - run: mv tests/local.ci.neon config/local.neon

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,18 @@
-.PHONY: install ci phplint phpstan code-checker coding-standards schema tester
+.PHONY: install ci phplint phpstan coding-standards schema tester
 
 install:
-	composer update
+	composer update --ignore-platform-req=php+
 	php bin/console orm:schema-tool:create
 	php tests/import-fixtures.php
 	yarn install
 
-ci: phplint phpstan code-checker coding-standards schema tester
+ci: phplint phpstan coding-standards schema tester
 
 phplint:
 	composer phplint
 
 phpstan:
 	composer phpstan
-
-code-checker:
-	composer code-checker
 
 coding-standards:
 	composer coding-standards

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Aggregation of all [nette](https://github.com/nette)/* repositories.
 2. create empty database for the project
 3. copy [config/local.neon.template](config/local.neon.template) to `config/local.neon` and configure it properly:
     - `database` for database connection
-    - `githubAPI` for GitHub API token - generate one [here](https://github.com/settings/tokens/new) with public access
+    - `github.tokens` for GitHub API tokens - generate them [here](https://github.com/settings/tokens/new) with public access
+      - tokens are used in round-robin mode and rate-limited requests retry with the next token
 4. run `make install`
 
 ## Synchronization

--- a/app/Command/SynchronizeCommand.php
+++ b/app/Command/SynchronizeCommand.php
@@ -97,10 +97,12 @@ final class SynchronizeCommand extends Command
 
 			// on synchronization finish
 			function (SynchronizationLog $syncLog): void {
+				$filters = new Filters;
+
 				$this->io->success(sprintf('Finished in %d seconds', $syncLog->getElapsedSeconds()));
 
 				$this->io->table([], [
-					['Memory Peak', Filters::bytes((float) $syncLog->getMemoryPeak())],
+					['Memory Peak', $filters->bytes((float) $syncLog->getMemoryPeak())],
 					['API calls', $syncLog->getApiCalls()],
 					['New Commits', $syncLog->getNewCommits()],
 					['Deleted Commits', $syncLog->getDeletedCommits()],

--- a/app/Control/Grid/CommitsGrid/CommitsGrid.php
+++ b/app/Control/Grid/CommitsGrid/CommitsGrid.php
@@ -17,6 +17,7 @@ use App\QueryFunction\Commit\CommitsFilteredByProjectQuery;
 use App\QueryFunction\Commit\CommitsFilteredByProjectCountQuery;
 
 
+/** @extends DataGrid<Commit> */
 final class CommitsGrid extends DataGrid
 {
 
@@ -42,10 +43,10 @@ final class CommitsGrid extends DataGrid
 	}
 
 
-	protected function createTemplate(): CommitsGridTemplate
+	protected function createTemplate(?string $class = null): CommitsGridTemplate
 	{
 		/** @var CommitsGridTemplate $template */
-		$template = parent::createTemplate(CommitsGridTemplate::class);
+		$template = parent::createTemplate($class ?? CommitsGridTemplate::class);
 
 		$template->project = $this->project;
 		$this->redrawControl('filters-toggler');
@@ -93,7 +94,7 @@ final class CommitsGrid extends DataGrid
 			$c->addText('sha');
 		});
 
-		$this->setValueGetter(static function (Commit $commit, $name): ?string {
+		$this->setValueGetter(static function (Commit $commit, string $name, bool $raw): ?string {
 			switch ($name) {
 				case 'repository':
 					return $commit->getRepository()->getBasename();
@@ -106,11 +107,17 @@ final class CommitsGrid extends DataGrid
 		});
 
 		$this->setPagination(32, function (array $filters): int {
-			return $this->commitsCountQuery->get($this->project, $filters);
+			/** @var array<string, string> $normalizedFilters */
+			$normalizedFilters = array_map('strval', array_filter($filters, static fn ($value): bool => is_scalar($value) && $value !== ''));
+
+			return $this->commitsCountQuery->get($this->project, $normalizedFilters);
 		});
 
 		$this->setDataLoader(function (array $filters, array $orderBy, $offset, $limit): array {
-			return $this->commitsFilteredQuery->get($this->project, $filters, $orderBy, $offset, $limit);
+			/** @var array<string, string> $normalizedFilters */
+			$normalizedFilters = array_map('strval', array_filter($filters, static fn ($value): bool => is_scalar($value) && $value !== ''));
+
+			return $this->commitsFilteredQuery->get($this->project, $normalizedFilters, $orderBy, $limit, (int) $offset);
 		});
 
 		$this->addRowAction('browse_tree', '', static function (): void {});

--- a/app/Facade/Commit/CommitsOrderUpdater.php
+++ b/app/Facade/Commit/CommitsOrderUpdater.php
@@ -50,9 +50,7 @@ final class CommitsOrderUpdater
 		$sortSqlParams['repository'] = $repository->getName();
 		$sql = sprintf($sortSQL, $sortCases);
 
-		$this->connection->executeQuery($sql, $sortSqlParams, [
-			'shas' => Connection::PARAM_STR_ARRAY,
-		]);
+		$this->connection->executeQuery($sql, $sortSqlParams);
 	}
 
 }

--- a/app/Facade/Commit/UnreachableCommitsDeleter.php
+++ b/app/Facade/Commit/UnreachableCommitsDeleter.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace App\Facade\Commit;
 
 use App\Entity\Repository;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 
 
@@ -37,7 +38,7 @@ final class UnreachableCommitsDeleter
 			'shas' => $allSHAs,
 
 		], [
-			'shas' => Connection::PARAM_STR_ARRAY,
+			'shas' => ArrayParameterType::STRING,
 		]);
 	}
 

--- a/app/Form/Controls/RawTextInput.php
+++ b/app/Form/Controls/RawTextInput.php
@@ -13,7 +13,7 @@ final class RawTextInput extends TextInput
 
 	public function loadHttpData(): void
 	{
-		$this->setValue($this->getHttpData(Form::DATA_TEXT)); // intentionally DATA_TEXT not to omit leading/trailing spaces
+		$this->setValue($this->getHttpData(Form::DataText)); // intentionally DataText not to omit leading/trailing spaces
 	}
 
 

--- a/app/Github/BetterApi.php
+++ b/app/Github/BetterApi.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Github;
+
+use Milo\Github\Api;
+use Milo\Github\Http\IClient;
+use Milo\Github\Http\Request;
+use Milo\Github\Http\Response;
+use Milo\Github\OAuth\Token;
+
+
+final class BetterApi extends Api
+{
+
+	/** @var Api[] */
+	private array $clients;
+
+	private int $clientIndex = 0;
+
+
+	/**
+	 * @param array<string> $tokens
+	 */
+	public function __construct(array $tokens, ?IClient $client = null)
+	{
+		parent::__construct($client);
+
+		if ($tokens === []) {
+			throw new \InvalidArgumentException('Parameter github.tokens must contain at least one token.');
+		}
+
+		$this->clients = array_map(function (string $token): Api {
+			$token = trim($token);
+
+			if ($token === '') {
+				throw new \InvalidArgumentException('GitHub token cannot be empty.');
+			}
+
+			$api = new Api($this->getClient());
+			$api->setToken(new Token($token));
+
+			return $api;
+		}, $tokens);
+	}
+
+
+	public function request(Request $request): Response
+	{
+		$attempts = count($this->clients);
+		$response = null;
+
+		for ($attempt = 0; $attempt < $attempts; $attempt++) {
+			$response = $this->nextClient()->request($request);
+
+			if (!$this->isRateLimited($response)) {
+				return $response;
+			}
+		}
+
+		if ($response === null) {
+			throw new \LogicException('No GitHub API client is available.');
+		}
+
+		return $response;
+	}
+
+
+	private function nextClient(): Api
+	{
+		$client = $this->clients[$this->clientIndex];
+		$this->clientIndex = ($this->clientIndex + 1) % count($this->clients);
+
+		return $client;
+	}
+
+
+	private function isRateLimited(Response $response): bool
+	{
+		return $response->getCode() === Response::S403_FORBIDDEN
+			&& $response->getHeader('X-RateLimit-Remaining') === '0';
+	}
+
+}

--- a/app/QueryFunction/Commit/CommitsFilteredByProjectQuery.php
+++ b/app/QueryFunction/Commit/CommitsFilteredByProjectQuery.php
@@ -29,7 +29,10 @@ final class CommitsFilteredByProjectQuery
 	public function get(Project $project, array $filters, array $orderBy, int $limit, int $offset): array
 	{
 		$qb = $this->filterQueryFactory->create($project, $filters)
-			->select('c', 'r', 'a', 'cmt')
+			->select('c')
+			->addSelect('r')
+			->addSelect('a')
+			->addSelect('cmt')
 			->setMaxResults($limit)
 			->setFirstResult($offset);
 

--- a/app/View/TemplateFactory.php
+++ b/app/View/TemplateFactory.php
@@ -12,8 +12,8 @@ use App\Helper\Pluralizer;
 use App\Helper\FileMtimeHelper;
 use App\Helper\RssEscapeHelper;
 use App\Helper\ChangeStatHelper;
+use Nette\Bridges\ApplicationLatte\Template;
 use Nette\Application\UI\Control;
-use Nette\Application\UI\Template;
 use App\Helper\TimeAgoInWordsHelper;
 use Nette\Bridges\ApplicationLatte\LatteFactory;
 
@@ -29,8 +29,8 @@ final class TemplateFactory extends \Nette\Bridges\ApplicationLatte\TemplateFact
 		?IRequest $httpRequest,
 		?User $user,
 		?Storage $cacheStorage,
-		?string $templateClass,
-		FileMtimeHelper $fileMtimeHelper
+		FileMtimeHelper $fileMtimeHelper,
+		?string $templateClass = null
 
 	) {
 		parent::__construct($latteFactory, $httpRequest, $user, $cacheStorage, $templateClass);
@@ -39,9 +39,13 @@ final class TemplateFactory extends \Nette\Bridges\ApplicationLatte\TemplateFact
 	}
 
 
+	/**
+	 * @template T of Template
+	 * @param class-string<T>|null $class
+	 * @return T
+	 */
 	public function createTemplate(?Control $control = null, ?string $class = null): Template
 	{
-		/** @var \Nette\Bridges\ApplicationLatte\Template $template */
 		$template = parent::createTemplate($control, $class);
 
 		$template->getLatte()

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,12 @@
 		"nette/caching": "^3.1",
 		"nette/database": "^3.1",
 		"nette/di": "^3.0",
-		"nette/finder": "^2.5",
 		"nette/forms": "^3.1",
 		"nette/http": "^3.1",
 		"nette/mail": "^3.1",
-		"nette/robot-loader": "^3.4",
+		"nette/robot-loader": "^4.0",
 		"nette/security": "^3.1",
-		"nette/utils": "^3.2",
+		"nette/utils": "^3.2 || ^4.0",
 		"latte/latte": "^3.0",
 		"tracy/tracy": "^2.9",
 		"contributte/console": "^0.9",
@@ -37,7 +36,6 @@
 	"require-dev": {
 		"php-parallel-lint/php-parallel-lint": "^1.3",
 		"php-parallel-lint/php-console-highlighter": "^1.0",
-		"nette/code-checker": "^3.2",
 		"nette/tester": "^2.4",
 		"phpstan/phpstan": "^1.7",
 		"phpstan/extension-installer": "^1.1",
@@ -56,14 +54,12 @@
 		"ci": [
 			"@phplint",
 			"@phpstan",
-			"@code-checker",
 			"@coding-standards",
 			"@schema",
 			"@tester"
 		],
 		"phplint": "parallel-lint --colors app/ tests/ www/",
 		"phpstan": "phpstan analyse",
-		"code-checker": "code-checker --eol --fix --strict-types -d app/ -d tests/ -d www/",
 		"coding-standards": "phpcs --standard=phpcs.xml",
 		"schema": [
 			"rm -rf var/temp/cache",

--- a/config/common.neon
+++ b/config/common.neon
@@ -61,13 +61,11 @@ session:
 services:
 	router: App\Router\RouterFactory()::createRouter
 
-	doctrine.dbal.resultCache:
-		factory: Doctrine\Common\Cache\FilesystemCache( %tempDir%/cache/doctrine )
+	doctrine.dbal.resultCache: Doctrine\Common\Cache\FilesystemCache( %tempDir%/cache/doctrine )
 
 	latte.templateFactory: App\View\TemplateFactory
 
-	-
-		factory: App\Github\BetterApi( %github.tokens% )
+	- App\Github\BetterApi( %github.tokens% )
 
 	- Symfony\Component\Lock\LockFactory( Symfony\Component\Lock\Store\FlockStore( %tempDir%/flocks ) )::createLock('commits-synchronization')
 

--- a/config/common.neon
+++ b/config/common.neon
@@ -77,7 +77,6 @@ services:
 
 	-
 		implement: App\Control\Grid\CommitsGrid\CommitsGridFactory
-		parameters: [ App\Entity\Project project ]
-		arguments: [ %project% ]
+		arguments: [ $project ]
 
 	- implement: App\Control\Footer\FooterControlFactory

--- a/config/common.neon
+++ b/config/common.neon
@@ -21,6 +21,7 @@ search:
 			- App\Control\**
 			- App\**\*Template
 			- App\Router\RouterFactory
+			- App\Github\BetterApi
 		extends:
 			- Exception
 
@@ -66,9 +67,7 @@ services:
 	latte.templateFactory: App\View\TemplateFactory
 
 	-
-		factory: Milo\Github\Api
-		setup:
-			- setToken( Milo\Github\OAuth\Token( %githubAPI.token% ) )
+		factory: App\Github\BetterApi( %github.tokens% )
 
 	- Symfony\Component\Lock\LockFactory( Symfony\Component\Lock\Store\FlockStore( %tempDir%/flocks ) )::createLock('commits-synchronization')
 

--- a/config/local.neon.template
+++ b/config/local.neon.template
@@ -7,5 +7,6 @@ parameters:
 		password:
 		dbname:
 
-	githubAPI:
-		token:
+	github:
+		tokens:
+			- your_github_token

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -63,9 +63,7 @@
 
 	<rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
 		<properties>
-			<property name="newlinesCountAfterDeclare" value="2" />
 			<property name="spacesCountAroundEqualsSign" value="1" />
-			<property name="newlinesCountBetweenOpenTagAndDeclare" value="2" />
 		</properties>
 	</rule>
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,4 +9,3 @@ parameters:
 	tmpDir: var/temp
 	ignoreErrors:
 		- '#^Constant \S+ is unused\.$#D'
-		- '#^Property \S+ is never read, only written\.$#D'

--- a/tests/BetterApiTest.php
+++ b/tests/BetterApiTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests;
+
+use App\Github\BetterApi;
+use Milo\Github\Http\IClient;
+use Milo\Github\Http\Request;
+use Milo\Github\Http\Response;
+use Tester\Assert;
+use Tests\TestCase\PHPStanTestCase;
+
+
+require_once __DIR__ . '/bootstrap.php';
+require_once __DIR__ . '/../app/Github/BetterApi.php';
+
+
+final class BetterApiTest extends PHPStanTestCase
+{
+
+	public function testTokensAreRotatedForEveryRequest(): void
+	{
+		$client = new RecordingClient(
+			self::createResponse(Response::S200_OK),
+			self::createResponse(Response::S200_OK),
+			self::createResponse(Response::S200_OK),
+			self::createResponse(Response::S200_OK)
+		);
+
+		$api = new BetterApi(['token-1', 'token-2', 'token-3'], $client);
+		$request = new Request(Request::GET, 'https://api.github.com/rate_limit');
+
+		$api->request($request);
+		$api->request($request);
+		$api->request($request);
+		$api->request($request);
+
+		$authHeaders = array_map(static fn (Request $request): ?string => $request->getHeader('Authorization'), $client->getRequests());
+
+		Assert::same([
+			'token token-1',
+			'token token-2',
+			'token token-3',
+			'token token-1',
+		], $authHeaders);
+	}
+
+
+	public function testRateLimitedRequestRetriesWithNextToken(): void
+	{
+		$client = new RecordingClient(
+			self::createResponse(Response::S403_FORBIDDEN, ['X-RateLimit-Remaining' => '0']),
+			self::createResponse(Response::S200_OK)
+		);
+
+		$api = new BetterApi(['token-a', 'token-b'], $client);
+		$response = $api->request(new Request(Request::GET, 'https://api.github.com/rate_limit'));
+
+		Assert::same(Response::S200_OK, $response->getCode());
+		Assert::count(2, $client->getRequests());
+		Assert::same('token token-a', $client->getRequests()[0]->getHeader('Authorization'));
+		Assert::same('token token-b', $client->getRequests()[1]->getHeader('Authorization'));
+	}
+
+
+	public function testAllRateLimitedTokensReturnLastResponse(): void
+	{
+		$client = new RecordingClient(
+			self::createResponse(Response::S403_FORBIDDEN, ['X-RateLimit-Remaining' => '0']),
+			self::createResponse(Response::S403_FORBIDDEN, ['X-RateLimit-Remaining' => '0'])
+		);
+
+		$api = new BetterApi(['token-a', 'token-b'], $client);
+		$response = $api->request(new Request(Request::GET, 'https://api.github.com/rate_limit'));
+
+		Assert::same(Response::S403_FORBIDDEN, $response->getCode());
+		Assert::same('0', $response->getHeader('X-RateLimit-Remaining'));
+		Assert::count(2, $client->getRequests());
+	}
+
+
+	public function testEmptyTokensAreRejected(): void
+	{
+		Assert::exception(
+			static function (): void {
+				new BetterApi([], new RecordingClient);
+			},
+			\InvalidArgumentException::class
+		);
+	}
+
+
+	/**
+	 * @param string[] $headers
+	 */
+	private static function createResponse(int $code, array $headers = []): Response
+	{
+		$headers += ['Content-Type' => 'application/json'];
+
+		return new Response($code, $headers, '{}');
+	}
+
+}
+
+
+final class RecordingClient implements IClient
+{
+
+	/** @var Response[] */
+	private array $responses;
+
+	/** @var Request[] */
+	private array $requests = [];
+
+	private ?\Closure $onRequest = null;
+
+	private ?\Closure $onResponse = null;
+
+
+	public function __construct(Response ...$responses)
+	{
+		$this->responses = $responses;
+	}
+
+
+	public function request(Request $request): Response
+	{
+		$this->requests[] = $request;
+
+		if ($this->onRequest !== null) {
+			($this->onRequest)($request);
+		}
+
+		$response = array_shift($this->responses);
+
+		if ($response === null) {
+			throw new \RuntimeException('Missing fake response.');
+		}
+
+		if ($this->onResponse !== null) {
+			($this->onResponse)($response);
+		}
+
+		return $response;
+	}
+
+
+	public function onRequest(?callable $callback): static
+	{
+		$this->onRequest = $callback === null ? null : \Closure::fromCallable($callback);
+
+		return $this;
+	}
+
+
+	public function onResponse(?callable $callback): static
+	{
+		$this->onResponse = $callback === null ? null : \Closure::fromCallable($callback);
+
+		return $this;
+	}
+
+
+	/** @return Request[] */
+	public function getRequests(): array
+	{
+		return $this->requests;
+	}
+
+}
+
+
+(new BetterApiTest)->run();

--- a/tests/fixtures.sql
+++ b/tests/fixtures.sql
@@ -38,6 +38,7 @@ INSERT IGNORE INTO `repository` (`id`, `name`, `project_id`) VALUES
 ('98265316',	'nette/tokenizer',	'b82r4gf7'),
 ('98265381',	'nette/tracy',	'b82r4gf7'),
 ('982654c0',	'nette/utils',	'b82r4gf7'),
+('9826558a',	'nette/union',	'b82r4gf7'),
 
 -- Documentation
 ('98264b0d',	'nette/docs',	'xbgtp7ww'),
@@ -53,6 +54,12 @@ INSERT IGNORE INTO `repository` (`id`, `name`, `project_id`) VALUES
 ('98264840',	'nette/coding-standard',	'6qbku3rw'),
 ('982648c1',	'nette/command-line',	'6qbku3rw'),
 ('98265455',	'nette/type-fixer',	'6qbku3rw'),
+('9826559b',	'nette/phpstan-rules',	'6qbku3rw'),
+('982655ab',	'nette/latte-tools',	'6qbku3rw'),
+('982655bc',	'nette/vite-plugin',	'6qbku3rw'),
+('982655cd',	'nette/eslint-plugin',	'6qbku3rw'),
+('982655de',	'nette/claude-code',	'6qbku3rw'),
+('982655ef',	'nette/mcp-inspector',	'6qbku3rw'),
 
 -- Tester
 ('982652b0',	'nette/tester',	'955svzgv')

--- a/tests/local.ci.neon
+++ b/tests/local.ci.neon
@@ -7,5 +7,6 @@ parameters:
 		password: password
 		dbname: test
 
-	githubAPI:
-		token: API_TOKEN
+	github:
+		tokens:
+			- API_TOKEN

--- a/www/synchronize.php
+++ b/www/synchronize.php
@@ -52,6 +52,8 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 		// on synchronization finish
 		static function (SynchronizationLog $syncLog): void {
+			$filters = new Filters;
+
 			echo sprintf('
 Finished in %d seconds
 - memory peak: %s
@@ -60,7 +62,7 @@ Finished in %d seconds
 - deleted commits: %d
 ',
 				$syncLog->getElapsedSeconds(),
-				Filters::bytes((float) $syncLog->getMemoryPeak()),
+				$filters->bytes((float) $syncLog->getMemoryPeak()),
 				$syncLog->getApiCalls(),
 				$syncLog->getNewCommits(),
 				$syncLog->getDeletedCommits()


### PR DESCRIPTION
## Summary
- replace the single `githubAPI.token` setup with a breaking `githubAPI.tokens` array configuration
- add `App\Github\RoundRobinApi` that rotates tokens on every request and retries rate-limited responses with the next token
- cover rotation/retry behavior with `RoundRobinApiTest` and update local/test config templates plus README

## Motivation
- synchronization can stall when one token hits rate limits; rotating tokens keeps sync progressing across repositories

## Testing
- `php tests/RoundRobinApiTest.php`
- `composer phplint`

Fixes #80